### PR TITLE
Improve AWS pagination and helm deployment

### DIFF
--- a/deploy/iam-role-manager/templates/statefulset.yaml
+++ b/deploy/iam-role-manager/templates/statefulset.yaml
@@ -21,15 +21,31 @@ spec:
         iam.amazonaws.com/role: {{ .Values.iamRole }}
       {{- end}}
     spec:
+    {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+    {{- end }}
     {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "iam-role-manager.fullname" . }}
     {{- end }}
+    {{- if and .Values.ssl.hostPath .Values.ssl.mountPath }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: {{ .Values.ssl.hostPath }}
+    {{- end}}
       containers:
       - command:
         - /root/manager
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
-        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ template "iam-role-manager.fullname" . }}
+      {{- if and .Values.ssl.hostPath .Values.ssl.mountPath }}
+        volumeMounts:
+          - name: ssl-certs
+            mountPath: {{ .Values.ssl.mountPath }}
+            readOnly: true
+      {{- end}}
         resources:
           limits:
             cpu: 100m

--- a/deploy/iam-role-manager/values.yaml
+++ b/deploy/iam-role-manager/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: ihoegen/iam-role-manager
   tag: latest
   pullPolicy: Always
+# pullSecret: some-secret  
 
 rbac:
   create: true


### PR DESCRIPTION
Hi!

This is a really interesting project, so thanks for starting it.  I was testing this out and found a few small things I needed to do to get this working.  

1) The pagination API for ListRolePolicies and ListAttachedRolePolicies always failed.  I'm not sure if the AWS API changed here, but [the docs](https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#ListRolePoliciesInput) indicates that the pagination API shouldn't be used on the first call -- only if the first call indicates that there are more results.  
2) I also needed to change the helm deploy to add imagePullSecrets and mount host ssl certificates into the container for CoreOS.  CoreOS uses a different path for this.

Please feel free to suggest changes or improvements. 