### PR TITLE
listPolicies functions fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/ihoe
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
+RUN apt-get update
+RUN apt-get install -y ca-certificates
+
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/ihoegen/iam-role-manager/manager .
 ENTRYPOINT ["./manager"]

--- a/pkg/controller/iamrole/aws.go
+++ b/pkg/controller/iamrole/aws.go
@@ -244,20 +244,39 @@ func isArn(policy string) bool {
 // Paginate over inline policies
 func (i *IAMClient) listInlinePolicies(roleName string) ([]string, error) {
 	var policyNamesPointers []*string
-	isTruncated := true
-	marker := "1"
-	for isTruncated {
-		currentPolicies, err := i.Client.ListRolePolicies(&iam.ListRolePoliciesInput{
+	currentPolicies, err := i.Client.ListRolePolicies(&iam.ListRolePoliciesInput{
 			RoleName: &roleName,
-			Marker:   &marker,
 		})
 		if err != nil {
 			return nil, err
 		}
-		policyNamesPointers = append(policyNamesPointers, currentPolicies.PolicyNames...)
-		marker = *currentPolicies.Marker
-		isTruncated = *currentPolicies.IsTruncated
-	}
+		isTruncated := *currentPolicies.IsTruncated
+		if isTruncated == true {
+        policyNamesPointers = append(policyNamesPointers, currentPolicies.PolicyNames...)
+        marker := *currentPolicies.Marker
+        for isTruncated {
+            currentPolicies, err := i.Client.ListRolePolicies(&iam.ListRolePoliciesInput{
+            RoleName: &roleName,
+            Marker:   &marker,
+            })
+						if err != nil {
+							return nil, err
+						}
+            policyNamesPointers = append(policyNamesPointers, currentPolicies.PolicyNames...)
+            isTruncated = *currentPolicies.IsTruncated
+            if isTruncated == true {
+                marker = *currentPolicies.Marker
+            }
+					}
+	    } else {
+	        currentPolicies, err := i.Client.ListRolePolicies(&iam.ListRolePoliciesInput{
+	            RoleName: &roleName,
+	        })
+					if err != nil {
+						return nil, err
+					}
+	        policyNamesPointers = append(policyNamesPointers, currentPolicies.PolicyNames...)
+	    }
 	var policyNameValues []string
 	for _, val := range policyNamesPointers {
 		policyNameValues = append(policyNameValues, *val)
@@ -268,20 +287,39 @@ func (i *IAMClient) listInlinePolicies(roleName string) ([]string, error) {
 // Paginate over attached policies
 func (i *IAMClient) listAttachedPolicies(roleName string) ([]iam.AttachedPolicy, error) {
 	var policyPointers []*iam.AttachedPolicy
-	isTruncated := true
-	marker := "1"
-	for isTruncated {
-		currentPolicies, err := i.Client.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+	currentPolicies, err := i.Client.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
 			RoleName: &roleName,
-			Marker:   &marker,
 		})
 		if err != nil {
 			return nil, err
 		}
-		policyPointers = append(policyPointers, currentPolicies.AttachedPolicies...)
-		marker = *currentPolicies.Marker
-		isTruncated = *currentPolicies.IsTruncated
-	}
+		isTruncated := *currentPolicies.IsTruncated
+		if isTruncated == true {
+				policyPointers = append(policyPointers, currentPolicies.AttachedPolicies...)
+				marker := *currentPolicies.Marker
+				for isTruncated {
+						currentPolicies, err := i.Client.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+						RoleName: &roleName,
+						Marker:   &marker,
+						})
+						if err != nil {
+							return nil, err
+						}
+						policyPointers = append(policyPointers, currentPolicies.AttachedPolicies...)
+						isTruncated = *currentPolicies.IsTruncated
+						if isTruncated == true {
+								marker = *currentPolicies.Marker
+						}
+					}
+			} else {
+					currentPolicies, err := i.Client.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+							RoleName: &roleName,
+					})
+					if err != nil {
+						return nil, err
+					}
+					policyPointers = append(policyPointers, currentPolicies.AttachedPolicies...)
+			}
 	var policyNameValues []iam.AttachedPolicy
 	for _, val := range policyPointers {
 		policyNameValues = append(policyNameValues, *val)


### PR DESCRIPTION
Fixed Dockerfile to prevent `Post https://iam.amazonaws.com/: x509: failed to load system roots and no roots provided` error.

Fixed pagination usage in `listAttachedPolicies` and `listInlinePolicies` functions.
Before this fix I got following error while executing
`kubectl describe iamrole test-iam-role`:
`
...
trimmed
...
Events:
  Type     Reason               Age   From     Message
  ----     ------               ----  ----     -------
  Warning  ErrorSyncingIAMRole  53m   iamrole  ValidationError: Invalid Marker.
           status code: 400, request id: 5137xxxx-xxxx-11e8-9cb9-29c73f9fxxxx
  Warning  ErrorSyncingIAMRole  36m  iamrole  ValidationError: Invalid Marker.
           status code: 400, request id: a566xxxx-xxxx-11e8-aaa7-81a45b09xxxx
  Warning  ErrorSyncingIAMRole  19m  iamrole  ValidationError: Invalid Marker.
           status code: 400, request id: f997xxxx-xxxx-11e98-9ff9-39d852a2xxxx
  Warning  ErrorSyncingIAMRole  3m9s  iamrole  ValidationError: Invalid Marker.
           status code: 400, request id: 4dc3xxxx-xxxx-11e8-a2e2-f93b9026xxxx`